### PR TITLE
security: add 7-day minimumReleaseAge install guard (Shai-Hulud wave 3)

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,4 @@
+[install]
+# Supply-chain guard (Shai-Hulud class attacks): only install package versions
+# published at least 7 days ago, giving the registry time to pull malware.
+minimumReleaseAge = 604800


### PR DESCRIPTION
## What

Adds `bunfig.toml` with `minimumReleaseAge = 604800` (7 days) — Bun refuses to
resolve any package version published less than a week ago.

## Why

The third Shai-Hulud wave went live **2026-08-04 ~09:00 UTC** via a GitHub
account takeover of the `keyv` / `cacheable` maintainer. It has since spread to
**443 packages across 2,235 poisoned versions** (~2B monthly installs) in 15
scopes, and is still spreading.

Every poisoned release adds `"preinstall": "node setup.mjs"`, which downloads a
real Bun binary and executes an encrypted payload that harvests cloud
credentials, GitHub tokens, Actions secrets, DB connection strings, private
keys and crypto wallets, then exfiltrates via GitHub dead-drop repos.

The malicious versions were published **with valid GitHub Actions provenance**,
so provenance checks and `npm audit` would not have caught them. A release-age
floor would have — every wave so far was yanked from the registry within hours.

## Scan result for this repo

Lockfile was scanned against the full Wiz IOC list (all 2,235 malicious
versions). **No compromised versions present.** This PR is preventative only —
it changes nothing about the current dependency tree.

## Notes

- No `bun install` was run to produce this PR; `bun.lock` is untouched.
- The guard only affects *future* resolutions. Next time someone runs
  `bun install`/`bun update`, week-old-or-newer versions are skipped.
- To install something newer deliberately: `bun add pkg --minimum-release-age=0`.
- Requires Bun ≥ 1.2.x; older versions ignore the unknown key harmlessly.

Reference: https://github.com/wiz-sec-public/wiz-research-iocs/blob/main/reports/keyv-packages.csv

🤖 Generated with [Claude Code](https://claude.com/claude-code)
