### PR TITLE
security: block npm installs in this bun repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 .DS_Store?
 node_modules
 dist
+
+# foreign lockfiles — this is a bun repo (bun.lock is the source of truth)
+package-lock.json
+pnpm-lock.yaml
+yarn.lock

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -12,5 +12,9 @@
   "devDependencies": {
     "@types/marked": "^5.0.2",
     "bun-types": "latest"
+  },
+  "engines": {
+    "bun": ">=1.3.0",
+    "npm": "use-bun-instead"
   }
 }


### PR DESCRIPTION
## What

Blocks accidental `npm install` (and stray foreign lockfiles) in this bun repo:

- `package.json` → `"engines": { "bun": ">=1.3.0", "npm": "use-bun-instead" }`
- `.npmrc` → `engine-strict=true`
- `.gitignore` → ignore `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`

## Why

The `minimumReleaseAge` supply-chain guard added earlier lives in `bunfig.toml`,
which **only bun reads**. An `npm install` run out of habit bypasses it entirely:
npm ignores `bun.lock`, re-resolves every `^`/`~` range to the newest published
version (including something published an hour ago), and drops a competing
`package-lock.json`. During an active npm worm that is the single easiest way to
get compromised in an otherwise-guarded repo.

With this change, `npm install` fails immediately — before resolving or fetching
anything — with a clear "Unsupported engine" error pointing at
`npm: use-bun-instead`. bun ignores both `engines` and `engine-strict`, so
nothing changes for normal workflows.

The `.gitignore` entries are the backstop: if someone bypasses the check, the
foreign lockfile can't be committed.

Also sets a floor of **bun >= 1.3.0** — below that, bun silently ignores
`minimumReleaseAge`, so older bun versions have no guard without knowing it.
(bun doesn't enforce `engines` by default; the floor is documentation plus
enforcement for any tooling that does check it.)

No install was run to produce this PR; `bun.lock` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
